### PR TITLE
fix: add new attributs sign if old format

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -162,6 +162,13 @@ def signWrangler(poi):
     if "Text1" in poi:
         for field in ["Text1", "Text2", "Text3", "Text4"]:
             poi[field] = jsonText(poi[field])
+        poi.update({
+            "back_text": {"has_glowing_text": 0, "color": "black", "messages": ["", "", "", ""]},
+            "front_text": {"has_glowing_text": 0, "color": "black",
+                           "messages": [poi["Text1"], poi["Text2"], poi["Text3"], poi["Text4"]]},
+            "keepPacked": 0,
+            "is_waxed": 0,
+        })
     else:
         for field in ["front_text", "back_text"]:
             if field in poi:


### PR DESCRIPTION
It's a fix to manage sign in version 1.20.X and lower. 


I updated my config to manage the new configuration (front/back) of the signs as below.
```
{
    'back_text': {'has_glowing_text': 0, 'color': 'black', 'messages': ['', '', '', '']},
    'front_text': {'has_glowing_text': 0, 'color': 'black', 'messages': ['$z:v:0:1:2', '', '', '']},
    'keepPacked': 0, 'is_waxed': 0, 'x': -381, 'y': 62, 'z': -372, 'id': 'minecraft:sign',
}
```

But on my map, I haven't visited all chunk since upgrading to 1.20.X, many sign have not `front_text` value.

I added a code to manage signs in the old format.

Before
```
{
    'id': 'minecraft:sign', 'keepPacked': 0, 'x': -381, 'y': 62, 'z': -372,
    'Color': 'black', 'GlowingText': 0, 
    'Text1': '$z:v:0:1:2', 'Text2': '', 'Text3': '', 'Text4': ''
}
```
After
```
{
    'back_text': {'has_glowing_text': 0, 'color': 'black', 'messages': ['', '', '', '']},
    'front_text': {'has_glowing_text': 0, 'color': 'black', 'messages': ['$z:v:0:1:2', '', '', '']},
    'keepPacked': 0, 'is_waxed': 0, 'x': -381, 'y': 62, 'z': -372, 'id': 'minecraft:sign',
    'Text1': '$z:v:0:1:2', 'Text2': '', 'Text3': '', 'Text4': ''
}
```