### PR TITLE
fix: Missing grass texture due to rename

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -1728,7 +1728,11 @@ def tall_grass(self, blockid, data):
     if data == 0: # dead shrub
         texture = self.load_image_texture(BLOCKTEXTURE + "dead_bush.png")
     elif data == 1: # tall grass
-        texture = self.load_image_texture(BLOCKTEXTURE + "grass.png")
+        try:
+            texture = self.load_image_texture(BLOCKTEXTURE + "short_grass.png")
+        except (TextureException, IOError):
+            # Attempt loading from the old name of this texture pre-1.20.3
+            texture = self.load_image_texture(BLOCKTEXTURE + "grass.png")
     elif data == 2: # fern
         texture = self.load_image_texture(BLOCKTEXTURE + "fern.png")
     elif data == 3: # Nether Sprouts

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -440,7 +440,8 @@ class RegionSet(object):
             'minecraft:sticky_piston': (29, 0),
             'minecraft:cobweb': (30, 0),
             'minecraft:dead_bush': (31, 0),
-            'minecraft:grass': (31, 1),
+            'minecraft:short_grass': (31, 1),
+            'minecraft:grass': (31, 1),  # Renamed to minecraft:short_grass in 1.20.3
             'minecraft:fern': (31, 2),
             'minecraft:piston': (33, 0),
             'minecraft:piston_head': (34, 0),


### PR DESCRIPTION
In 1.20.3, Grass was renamed to Short Grass, and the block ID was updated at the same time. This means the texture file was also renamed, and thus Overviewer cannot find it when given a newer client JAR to load textures from.