### PR TITLE
Minecraft 1.25.5 - Spring to Life

### DIFF
--- a/overviewer_core/src/overviewer.h
+++ b/overviewer_core/src/overviewer.h
@@ -31,7 +31,7 @@
 
 // increment this value if you've made a change to the c extension
 // and want to force users to rebuild
-#define OVERVIEWER_EXTENSION_VERSION 124
+#define OVERVIEWER_EXTENSION_VERSION 125
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/overviewer_core/src/primitives/base.c
+++ b/overviewer_core/src/primitives/base.c
@@ -106,8 +106,8 @@ base_draw(void* data, RenderState* state, PyObject* src, PyObject* mask, PyObjec
         (state->block == block_grass && get_data(state, BLOCKS, state->x, state->y + 1, state->z) != 78) ||
         block_class_is_subset(state->block, (mc_block_t[]){block_vine, block_waterlily, block_flowing_water, block_water, block_leaves},
                               5) ||
-        /* tallgrass, but not dead shrubs */
-        (state->block == block_tallgrass && state->block_data != 0) ||
+        /* tallgrass, but not dead shrubs or dry grass */
+        (state->block == block_tallgrass && state->block_data != 0 && state->block_data != 4 && state->block_data != 5) ||
         /* pumpkin/melon stem, not fully grown. Fully grown stems
          * get constant brown color (see textures.py) */
         (((state->block == block_pumpkin_stem) || (state->block == block_melon_stem)) && (state->block_data != 7)) ||

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -7477,13 +7477,13 @@ def difficult_heads(self, blockid, data):
     return None
 
 
-@material(blockid=[1142], data=[0,1,2,4,5,6])
+@material(blockid=[1142], data=[0, 1, 2, 4, 5, 6, 8, 9, 10])
 def creaking_heart(self, blockid, data):
     # bits
-    #   active
-    #   | axis
-    #   | |
-    # 0b000
+    #    state (0, 1, 2)
+    #    | axis (0, 1, 2)
+    #    | |
+    # 0b0000
 
     orientation = data & 3
 
@@ -7493,10 +7493,11 @@ def creaking_heart(self, blockid, data):
         elif orientation == 2:
             orientation = 1
 
-    active = "_active" if data & 4 else ""
+    state_key = data >> 2
+    state = {0: '', 1: '_dormant', 2: '_awake'}[state_key]
 
-    top = self.load_image_texture(BLOCKTEXTURE + "creaking_heart_top" + active + ".png")
-    side = self.load_image_texture(BLOCKTEXTURE + "creaking_heart" + active + ".png")
+    top = self.load_image_texture(BLOCKTEXTURE + "creaking_heart_top" + state + ".png")
+    side = self.load_image_texture(BLOCKTEXTURE + "creaking_heart" + state + ".png")
 
     # choose orientation and paste textures
     if orientation == 0:

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -4672,7 +4672,7 @@ def comparator(self, blockid, data):
     
 # trapdoor
 # the trapdoor is looks like a sprite when opened, that's not good
-@material(blockid=[96,167,11332,11333,11334,11335,11336,12501,12502, 1198, 1207, 1218, 1230, 1231, 12658, 12659, 12660, 12661, 1137],
+@material(blockid=[96,167,11332,11333,11334,11335,11336,12501,12502, 1198, 1207, 1218, 1231, 12658, 12659, 12660, 12661, 1137],
           data=list(range(16)), transparent=True, nospawn=True)
 def trapdoor(self, blockid, data):
 
@@ -4709,7 +4709,6 @@ def trapdoor(self, blockid, data):
                    1207:BLOCKTEXTURE + "cherry_trapdoor.png",
                    1218:BLOCKTEXTURE + "bamboo_trapdoor.png",
                    1137:BLOCKTEXTURE + "pale_oak_trapdoor.png",
-                   1230:BLOCKTEXTURE + "pink_petals.png",
                    1231:BLOCKTEXTURE + "frogspawn.png",
 
                    12658: BLOCKTEXTURE + "copper_trapdoor.png",
@@ -7549,6 +7548,40 @@ def pale_moss_carpet(self, blockid, data):
         return tex
 
     return self.build_full_block(None, side_select(0), side_select(1), side_select(3), side_select(2), bottom=bottomTex)
+
+
+@material(blockid=[1230, 1149, 1221], data=list(range(0b1111 + 1)), transparent=True)
+def ground_cover(self, blockid, data):
+    # bits!
+    # LS 2 bits = direction
+    # MS 2 bits = segment count
+
+    texture = self.load_image_texture(BLOCKTEXTURE + {
+        1230: "pink_petals.png",
+        1149: "wildflowers.png",
+        1221: "leaf_litter.png",
+    }[blockid])
+
+    segment_count = (data & 0b1100) >> 2
+
+    target = Image.new("RGBA", (16, 16), self.bgcolor)
+    alpha_over(target, texture.crop((0, 0, 8, 8)), (0, 0))
+
+    if segment_count >= 1:
+        alpha_over(target, texture.crop((0, 8, 8, 16)), (0, 8))
+    if segment_count >= 2:
+        alpha_over(target, texture.crop((8, 8, 16, 16)), (8, 8))
+    if segment_count >= 3:
+        alpha_over(target, texture.crop((8, 0, 16, 8)), (8, 0))
+
+    direction = data & 0b0011
+    direction += self.rotation
+
+    for i in range(direction):
+        target = target.rotate(270)
+
+    return self.build_full_block(None, None, None, None, None, target)
+
 
 sprite(blockid=11385, imagename=BLOCKTEXTURE + "oak_sapling.png")
 sprite(blockid=11386, imagename=BLOCKTEXTURE + "spruce_sapling.png")

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -7583,6 +7583,12 @@ def ground_cover(self, blockid, data):
     return self.build_full_block(None, None, None, None, None, target)
 
 
+@material(blockid=[36], data=list(range(4)))
+def test_block(self, _, data):
+    tex = self.load_image_texture(BLOCKTEXTURE + 'test_block_' + ['start','accept','fail','log'][data] + '.png')
+    return self.build_block(tex, tex)
+
+
 sprite(blockid=11385, imagename=BLOCKTEXTURE + "oak_sapling.png")
 sprite(blockid=11386, imagename=BLOCKTEXTURE + "spruce_sapling.png")
 sprite(blockid=11387, imagename=BLOCKTEXTURE + "birch_sapling.png")
@@ -7618,6 +7624,7 @@ block(blockid=1248, top_image=BLOCKTEXTURE + "suspicious_gravel_0.png")
 block(blockid=1229, top_image=BLOCKTEXTURE + "target_top.png", side_image=BLOCKTEXTURE + "target_side.png")
 block(blockid=1244, top_image=BLOCKTEXTURE + "sculk_catalyst_top.png", side_image=BLOCKTEXTURE + "sculk_catalyst_side.png")
 block(blockid=25, top_image=BLOCKTEXTURE + "note_block.png")
+block(blockid=37, top_image=BLOCKTEXTURE + "test_instance_block.png")
 block(blockid=41, top_image=BLOCKTEXTURE + "gold_block.png")
 block(blockid=42, top_image=BLOCKTEXTURE + "iron_block.png")
 block(blockid=45, top_image=BLOCKTEXTURE + "bricks.png")

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -7607,6 +7607,8 @@ sprite(blockid=1016, imagename=BLOCKTEXTURE + "warped_fungus.png")
 sprite(blockid=1017, imagename=BLOCKTEXTURE + "crimson_fungus.png")
 sprite(blockid=1018, imagename=BLOCKTEXTURE + "warped_roots.png")
 sprite(blockid=1019, imagename=BLOCKTEXTURE + "crimson_roots.png")
+sprite(blockid=258, imagename=BLOCKTEXTURE + "bush.png")
+sprite(blockid=259, imagename=BLOCKTEXTURE + "firefly_bush.png")
 
 block(blockid=4, top_image=BLOCKTEXTURE + "cobblestone.png")
 block(blockid=7, top_image=BLOCKTEXTURE + "bedrock.png")

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -1709,23 +1709,30 @@ def piston_extension(self, blockid, data):
 
     return img
 
-@material(blockid=31, data=list(range(4)), transparent=True)
-def tall_grass(self, blockid, data):
-    if data == 0: # dead shrub
-        texture = self.load_image_texture(BLOCKTEXTURE + "dead_bush.png")
-    elif data == 1: # tall grass
-        try:
-            texture = self.load_image_texture(BLOCKTEXTURE + "short_grass.png")
-        except (TextureException, IOError):
-            # Attempt loading from the old name of this texture pre-1.20.3
-            texture = self.load_image_texture(BLOCKTEXTURE + "grass.png")
-    elif data == 2: # fern
-        texture = self.load_image_texture(BLOCKTEXTURE + "fern.png")
-    elif data == 3: # Nether Sprouts
-        texture = self.load_image_texture(BLOCKTEXTURE + "nether_sprouts.png")
+@material(blockid=[31], data=list(range(6)), transparent=True)
+def tall_grass(self, _, data):
+    grass_map = [
+        "dead_bush",
+        ["short_grass", "grass"],
+        "fern",
+        "nether_sprouts",
+        "short_dry_grass",
+        "tall_dry_grass",
+    ]
 
-    
+    if isinstance(grass_map[data], list):
+        texture = None
+        for tex in grass_map[data]:
+            try:
+                texture = self.load_image_texture(BLOCKTEXTURE + tex + ".png")
+                break
+            except (TextureException, IOError):
+                continue
+    else:
+        texture = self.load_image_texture(BLOCKTEXTURE + grass_map[data] + ".png")
+
     return self.build_billboard(texture)
+
 
 # dead bush
 billboard(blockid=32, imagename=BLOCKTEXTURE + "dead_bush.png")
@@ -1737,11 +1744,11 @@ def wool(self, blockid, data):
     return self.build_block(texture, texture)
 
 # flowers
-@material(blockid=38, data=list(range(15)), transparent=True)
+@material(blockid=38, data=list(range(16)), transparent=True)
 def flower(self, blockid, data):
     flower_map = ["poppy", "blue_orchid", "allium", "azure_bluet", "red_tulip", "orange_tulip",
                   "white_tulip", "pink_tulip", "oxeye_daisy", "dandelion", "wither_rose",
-                  "cornflower", "lily_of_the_valley", "closed_eyeblossom", "open_eyeblossom"]
+                  "cornflower", "lily_of_the_valley", "closed_eyeblossom", "open_eyeblossom", "cactus_flower"]
     texture = self.load_image_texture(BLOCKTEXTURE + "%s.png" % flower_map[data])
     return self.build_billboard(texture)
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -450,6 +450,8 @@ class RegionSet(object):
             'minecraft:short_grass': (31, 1),
             'minecraft:grass': (31, 1),  # Renamed to minecraft:short_grass in 1.20.3
             'minecraft:fern': (31, 2),
+            'minecraft:short_dry_grass': (31, 4),
+            'minecraft:tall_dry_grass': (31, 5),
             'minecraft:piston': (33, 0),
             'minecraft:piston_head': (34, 0),
             'minecraft:white_wool': (35, 0),
@@ -488,6 +490,7 @@ class RegionSet(object):
             "minecraft:lily_of_the_valley": (38, 12),
             "minecraft:closed_eyeblossom": (38, 13),
             "minecraft:open_eyeblossom": (38, 14),
+            "minecraft:cactus_flower": (38, 15),
 
             'minecraft:brown_mushroom': (39, 0),
             'minecraft:red_mushroom': (40, 0),

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -468,6 +468,10 @@ class RegionSet(object):
             'minecraft:green_wool': (35, 13),
             'minecraft:red_wool': (35, 14),
             'minecraft:black_wool': (35, 15),
+
+            'minecraft:test_block': (36, 0),
+            'minecraft:test_instance_block': (37, 0),
+
             # Flowers
             'minecraft:poppy': (38, 0),
             'minecraft:blue_orchid': (38, 1),
@@ -1997,6 +2001,10 @@ class RegionSet(object):
                 amount = int(palette_entry['Properties']['flower_amount'])
 
             data |= (amount - 1) << 2
+
+        elif key == 'minecraft:test_block':
+            p = palette_entry['Properties']
+            data = ['start','accept','fail','log'].index(p['test_block_mode'])
 
         return (block, data)
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1194,8 +1194,10 @@ class RegionSet(object):
             'minecraft:target': (1229, 0),
             # Nether Sprout
             'minecraft:nether_sprouts': (31, 3),
-            # Pink Petals
+            # Ground cover
             'minecraft:pink_petals': (1230, 0),
+            'minecraft:wildflowers': (1149, 0),
+            'minecraft:leaf_litter': (1221, 0),
             # Frogspawn
             'minecraft:frogspawn': (1231, 0),
             # Amethyst Cluster
@@ -1984,6 +1986,17 @@ class RegionSet(object):
 
             if p['bottom'] == 'true':
                 data |= 1
+
+        elif key in ('minecraft:pink_petals', 'minecraft:wildflowers', 'minecraft:leaf_litter'):
+            facing = palette_entry['Properties']['facing']
+            data = {'north': 0, 'east': 1, 'south': 2, 'west': 3}[facing]
+
+            if key == 'minecraft:leaf_litter':
+                amount = int(palette_entry['Properties']['segment_amount'])
+            else:
+                amount = int(palette_entry['Properties']['flower_amount'])
+
+            data |= (amount - 1) << 2
 
         return (block, data)
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -2004,7 +2004,7 @@ class RegionSet(object):
 
         elif key == 'minecraft:test_block':
             p = palette_entry['Properties']
-            data = ['start','accept','fail','log'].index(p['test_block_mode'])
+            data = ['start','accept','fail','log'].index(p['mode'])
 
         return (block, data)
 

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -1632,10 +1632,11 @@ class RegionSet(object):
             data = {'y': 0, 'x': 1, 'z': 2}[axis]
         elif key == 'minecraft:creaking_heart':
             axis = palette_entry['Properties']['axis']
-            active = palette_entry['Properties']['active'] == 'true'
+            state = palette_entry['Properties']['creaking_heart_state']
 
-            data = {'y': 0, 'x': 1, 'z': 2}[axis]
-            data |= 4 if active else 0
+            data = {'uprooted': 0, 'dormant': 1, 'awake': 2}[state]
+            data <<= 2
+            data |= {'y': 0, 'x': 1, 'z': 2}[axis]
 
         elif key in ['minecraft:redstone_torch','minecraft:redstone_wall_torch','minecraft:wall_torch',
                     'minecraft:soul_torch', 'minecraft:soul_wall_torch']:

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -801,6 +801,9 @@ class RegionSet(object):
             'minecraft:jigsaw': (256, 0),
             'minecraft:shulker_box': (257, 0),
 
+            'minecraft:bush': (258, 0),
+            'minecraft:firefly_bush': (259, 0),
+
             'minecraft:armor_stand': (416, 0),  # not rendering
 
             # Underwater things that we currently render as water


### PR DESCRIPTION
Implements the new blocks added in 1.21.5:

* [x] Leaf Litter
* [x] Wildflowers
* [x] Creaking Heart state changes
* [x] Test block
* [x] Test instance block
* [x] Bush & Firefly bush
* [x] Cactus flower
* [x] Short + tall dry grass

Not implemented:
* [ ] Changes to leaf litter (biome tints) - #89 

Implemented as part of a separate PR:
* [x] Text Component Data Format changes - #87 
