### PR TITLE
Removed import: imp to accommodate to Ubuntu 24.04 package build.

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: v1.21.1
+  VERSION: 1.21.1
 
 jobs:
   build_and_release_windows:
@@ -26,8 +26,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          git tag ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
+          git tag v${{ env.VERSION }}
+          git push origin v${{ env.VERSION }}
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          git tag v${{ env.VERSION }}
-          git push origin v${{ env.VERSION }}
+          git tag ${{ env.VERSION }}
+          git push origin ${{ env.VERSION }}
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create ZIP file for Windows
         run: |
-          Compress-Archive -Path .\dist\overviewer -DestinationPath overviewer-v${{ env.VERSION }}-windows.zip
+          Compress-Archive -Path .\dist\overviewer -DestinationPath overviewer-${{ env.VERSION }}-windows.zip
       - name: Create Release Notes
         uses: johnyherangi/create-release-notes@main
         id: create-release-notes
@@ -57,8 +57,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ env.VERSION }}
-          release_name: The Minecraft Overviewer v${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
+          release_name: The Minecraft Overviewer ${{ env.VERSION }}
           body: ${{ steps.create-release-notes.outputs.release-notes }}
           draft: false
           prerelease: false
@@ -70,8 +70,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_windows.outputs.upload_url }}
-          asset_path: ./overviewer-v${{ env.VERSION }}-windows.zip
-          asset_name: overviewer-v${{ env.VERSION }}-windows.zip
+          asset_path: ./overviewer-${{ env.VERSION }}-windows.zip
+          asset_name: overviewer-${{ env.VERSION }}-windows.zip
           asset_content_type: application/zip
 
     outputs:
@@ -111,9 +111,9 @@ jobs:
       - name: Create tar.xz archive for Linux
         run: |
           cd dist
-          tar -cf overviewer-v${{ env.VERSION }}-linux.tar overviewer
-          xz -z overviewer-v${{ env.VERSION }}-linux.tar
-          mv overviewer-v${{ env.VERSION }}-linux.tar.xz ../overviewer-v${{ env.VERSION }}-linux.tar.xz
+          tar -cf overviewer-${{ env.VERSION }}-linux.tar overviewer
+          xz -z overviewer-${{ env.VERSION }}-linux.tar
+          mv overviewer-${{ env.VERSION }}-linux.tar.xz ../overviewer-${{ env.VERSION }}-linux.tar.xz
       - name: Get upload URL
         run: 'echo "Upload URL: ${{ needs.build_and_release_windows.outputs.upload_url }}"'
 
@@ -124,8 +124,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.build_and_release_windows.outputs.upload_url }}
-          asset_path: ./overviewer-v${{ env.VERSION }}-linux.tar.xz
-          asset_name: overviewer-v${{ env.VERSION }}-linux.tar.xz
+          asset_path: ./overviewer-${{ env.VERSION }}-linux.tar.xz
+          asset_name: overviewer-${{ env.VERSION }}-linux.tar.xz
           asset_content_type: application/x-xz
 
   build_and_release_debian:
@@ -182,6 +182,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.build_and_release_windows.outputs.upload_url }}
-          asset_path: ../the-minecraft-overviewer_v${{ env.VERSION }}-0_amd64.deb
-          asset_name: overviewer-v${{ env.VERSION }}-x86_64-${{ matrix.os }}.deb
+          asset_path: ../the-minecraft-overviewer_${{ env.VERSION }}-0_amd64.deb
+          asset_name: overviewer-${{ env.VERSION }}-x86_64-${{ matrix.os }}.deb
           asset_content_type: application/x-deb

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.1
+  VERSION: v1.21.1
 
 jobs:
   build_and_release_windows:
@@ -111,9 +111,9 @@ jobs:
       - name: Create tar.xz archive for Linux
         run: |
           cd dist
-          tar -cf overviewer-${{ env.VERSION }}-LINUX.tar overviewer
-          xz -z overviewer-${{ env.VERSION }}-LINUX.tar
-          mv overviewer-${{ env.VERSION }}-LINUX.tar.xz ../overviewer-${{ env.VERSION }}-LINUX.tar.xz
+          tar -cf overviewer-${{ env.VERSION }}-linux.tar overviewer
+          xz -z overviewer-${{ env.VERSION }}-linux.tar
+          mv overviewer-${{ env.VERSION }}-linux.tar.xz ../overviewer-${{ env.VERSION }}-linux.tar.xz
       - name: Get upload URL
         run: 'echo "Upload URL: ${{ needs.build_and_release_windows.outputs.upload_url }}"'
 
@@ -124,8 +124,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.build_and_release_windows.outputs.upload_url }}
-          asset_path: ./overviewer-${{ env.VERSION }}-LINUX.tar.xz
-          asset_name: overviewer-v${{ env.VERSION }}-LINUX.tar.xz
+          asset_path: ./overviewer-${{ env.VERSION }}-linux.tar.xz
+          asset_name: overviewer-v${{ env.VERSION }}-linux.tar.xz
           asset_content_type: application/x-xz
 
   build_and_release_debian:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.12
+  VERSION: 1.21.13
 
 jobs:
   build_and_release_windows:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create ZIP file for Windows
         run: |
-          Compress-Archive -Path .\dist\overviewer -DestinationPath overviewer-${{ env.VERSION }}-windows.zip
+          Compress-Archive -Path .\dist\overviewer -DestinationPath overviewer-v${{ env.VERSION }}-windows.zip
       - name: Create Release Notes
         uses: johnyherangi/create-release-notes@main
         id: create-release-notes
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
           release_name: The Minecraft Overviewer v${{ env.VERSION }}
           body: ${{ steps.create-release-notes.outputs.release-notes }}
           draft: false
@@ -70,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_windows.outputs.upload_url }}
-          asset_path: ./overviewer-${{ env.VERSION }}-windows.zip
+          asset_path: ./overviewer-v${{ env.VERSION }}-windows.zip
           asset_name: overviewer-v${{ env.VERSION }}-windows.zip
           asset_content_type: application/zip
 
@@ -111,9 +111,9 @@ jobs:
       - name: Create tar.xz archive for Linux
         run: |
           cd dist
-          tar -cf overviewer-${{ env.VERSION }}-linux.tar overviewer
-          xz -z overviewer-${{ env.VERSION }}-linux.tar
-          mv overviewer-${{ env.VERSION }}-linux.tar.xz ../overviewer-${{ env.VERSION }}-linux.tar.xz
+          tar -cf overviewer-v${{ env.VERSION }}-linux.tar overviewer
+          xz -z overviewer-v${{ env.VERSION }}-linux.tar
+          mv overviewer-v${{ env.VERSION }}-linux.tar.xz ../overviewer-v${{ env.VERSION }}-linux.tar.xz
       - name: Get upload URL
         run: 'echo "Upload URL: ${{ needs.build_and_release_windows.outputs.upload_url }}"'
 
@@ -124,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.build_and_release_windows.outputs.upload_url }}
-          asset_path: ./overviewer-${{ env.VERSION }}-linux.tar.xz
+          asset_path: ./overviewer-v${{ env.VERSION }}-linux.tar.xz
           asset_name: overviewer-v${{ env.VERSION }}-linux.tar.xz
           asset_content_type: application/x-xz
 
@@ -182,6 +182,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.build_and_release_windows.outputs.upload_url }}
-          asset_path: ../the-minecraft-overviewer_${{ env.VERSION }}-0_amd64.deb
+          asset_path: ../the-minecraft-overviewer_v${{ env.VERSION }}-0_amd64.deb
           asset_name: overviewer-v${{ env.VERSION }}-x86_64-${{ matrix.os }}.deb
           asset_content_type: application/x-deb

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.13
+  VERSION: 1.21.14
 
 jobs:
   build_and_release_windows:
@@ -131,7 +131,7 @@ jobs:
   build_and_release_debian:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     needs: build_and_release_windows
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'  && vars.START_BUILD == 'True'
@@ -150,7 +150,7 @@ jobs:
       - name: Install Dependencies (apt)
         run: |
           sudo apt-get update -y
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev libjpeg-dev devscripts python3-all-dev debhelper python3-pil python3-numpy dh-python
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev libjpeg-dev devscripts python3-all-dev debhelper python3-pil python3-numpy dh-python build-essential
 
       - name: Install Dependencies (pip)
         run: pip install -r requirements.txt

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.1
+  VERSION: 1.21.12
 
 jobs:
   build_and_release_windows:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.11
+  VERSION: 1.21.1
 
 jobs:
   build_and_release_windows:
@@ -131,7 +131,7 @@ jobs:
   build_and_release_debian:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     needs: build_and_release_windows
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'  && vars.START_BUILD == 'True'

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.14
+  VERSION: 1.21.13
 
 jobs:
   build_and_release_windows:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.21.1
+  VERSION: 1.21.11
 
 jobs:
   build_and_release_windows:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -131,7 +131,7 @@ jobs:
   build_and_release_debian:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     needs: build_and_release_windows
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'  && vars.START_BUILD == 'True'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: python-pillow/Pillow
-          ref: refs/tags/10.2.0
+          ref: refs/tags/10.3.0
           path: pillow
           sparse-checkout: |
             src/libImaging

--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -15,7 +15,6 @@
 
 from collections import OrderedDict, deque
 import sys
-import imp
 import os
 import os.path
 import zipfile
@@ -199,7 +198,7 @@ class Textures(object):
         if os.path.isfile(path):
             if verbose: logging.info("Found %s in '%s'", filename, path)
             return open(path, mode)
-        elif hasattr(sys, "frozen") or imp.is_frozen("__main__"):
+        elif hasattr(sys, "frozen"):
             # windows special case, when the package dir doesn't exist
             path = os.path.join(programdir, "textures", filename)
             if os.path.isfile(path):

--- a/overviewer_core/util.py
+++ b/overviewer_core/util.py
@@ -18,7 +18,6 @@ Misc utility routines used by multiple files that don't belong anywhere else
 """
 
 import errno
-import imp
 import os.path
 import platform
 import sys
@@ -28,15 +27,16 @@ from subprocess import PIPE, Popen
 
 
 def get_program_path():
-    if hasattr(sys, "frozen") or imp.is_frozen("__main__"):
+    # Check if running as a frozen executable (e.g., created with PyInstaller)
+    if getattr(sys, "frozen", False):
         return os.path.dirname(sys.executable)
-    else:
-        try:
-            # normally, we're in ./overviewer_core/util.py
-            # we want ./
-            return os.path.dirname(os.path.dirname(__file__))
-        except NameError:
-            return os.path.dirname(sys.argv[0])
+    
+    # If not frozen, attempt to use __file__ or sys.argv[0] to determine the script path
+    try:
+        return os.path.dirname(os.path.dirname(__file__))  # For normal script run
+    except NameError:
+        # Fall back to sys.argv[0] if __file__ is not available (e.g., when running interactively)
+        return os.path.dirname(sys.argv[0])
 
 
 def findGitHash():


### PR DESCRIPTION
Upon testing the GitHub Action to build for Ubuntu 24.04 I have found that `import imp`, while supported in Python 3.810. It is removed in Python 3.9.

After removing `import imp` and modifying the code and building Overviewer in a python 3.8.10 environment for Windows, everything is working as expected.

Build for Windows, Linux, Ubuntu 20.04, 22.04 and 24.04 are passing.

GitHub actions:
[Pytest](https://github.com/Gregory-AM/The-Minecraft-Overviewer-Debian/actions/runs/13346965114)
[Build and Release](https://github.com/Gregory-AM/The-Minecraft-Overviewer-Debian/actions/runs/13346965111)

Testing in Ubuntu 24.04 VM:
Working as intended