### PR TITLE
Restore old world path resolution lookup behaviour

### DIFF
--- a/overviewer.py
+++ b/overviewer.py
@@ -312,6 +312,11 @@ def main():
     if not args.config:
         # No config file mode.
         worldpath = resolve_world_path(args.world)
+
+        if not worldpath:
+            logging.error(f"World '{worldpath}' not found; does it exist in the current folder or in the Minecraft saves directory?")
+            return 1
+
         destdir = os.path.expanduser(args.output)
         logging.debug("Using %r as the world directory", worldpath)
         logging.debug("Using %r as the output directory", destdir)
@@ -668,6 +673,19 @@ def list_worlds():
               "repaired before Overviewer can render them.")
 
 def resolve_world_path(world_input):
+    """
+    Find the world save folder for the specified input
+
+    If the world save folder exists in the current directory, it will be returned.
+    Otherwise, look in the platform Minecraft saves folder for a world directory with that name.
+    """
+    # See if the provided path actually exists
+    if os.path.exists(world_input):
+        return world_input
+
+    if os.path.sep in world_input:
+        return None
+
     # Get standard Minecraft saves directory for current OS
     if platform.system() == "Windows":
         mc_saves = os.path.join(os.path.expanduser("~"), "AppData", "Roaming", ".minecraft", "saves")
@@ -680,14 +698,8 @@ def resolve_world_path(world_input):
     world_path = os.path.join(mc_saves, world_input)
     if os.path.exists(world_path):
         return world_path
-        
-    # If not found in saves, check if it's a full path
-    if os.path.exists(world_input):
-        return world_input
-        
-    # If still not found, display user-friendly error
-    logging.error(f"World '{world_input}' not found in Minecraft saves directory: {mc_saves}")
-    sys.exit(1)
+
+    return None
 
 
 if __name__ == "__main__":

--- a/test/test_overviewer.py
+++ b/test/test_overviewer.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch
+import overviewer
+
+class OverviewerTest(unittest.TestCase):
+
+    @patch('os.path.sep', new='/')
+    @patch('os.path.expanduser', return_value='/home/user')
+    @patch('platform.system', return_value='Linux')
+    @patch('os.path.exists')
+    def test_resolve_local_only(self, mock_exists, *args):
+        mock_exists.side_effect = lambda path: {
+            "foo": True,
+            "/home/user/.minecraft/saves/foo": False
+        }[path]
+
+        self.assertEqual(overviewer.resolve_world_path("foo"), "foo")
+
+
+    @patch('os.path.sep', new='/')
+    @patch('os.path.expanduser', return_value='/home/user')
+    @patch('platform.system', return_value='Linux')
+    @patch('os.path.exists')
+    def test_resolve_local_and_saves(self, mock_exists, *args):
+        """If the world directory exists in the current directory, that should be preferred"""
+        mock_exists.side_effect = lambda path: {
+            "foo": True,
+            "/home/user/.minecraft/saves/foo": True
+        }[path]
+
+        self.assertEqual(overviewer.resolve_world_path("foo"), "foo")
+
+
+    @patch('os.path.sep', new='/')
+    @patch('os.path.expanduser', return_value='/home/user')
+    @patch('platform.system', return_value='Linux')
+    @patch('os.path.exists')
+    def test_resolve_saves_only(self, mock_exists, *args):
+        mock_exists.side_effect = lambda path: {
+            "foo": False,
+            "/home/user/.minecraft/saves/foo": True
+        }[path]
+
+        self.assertEqual(overviewer.resolve_world_path("foo"), "/home/user/.minecraft/saves/foo")
+
+    @patch('os.path.sep', new='/')
+    @patch('os.path.expanduser', return_value='/home/user')
+    @patch('platform.system', return_value='Linux')
+    @patch('os.path.exists')
+    def test_resolve_local_only_with_sep(self, mock_exists, *args):
+        mock_exists.side_effect = lambda path: {
+            "foo/bar": True,
+            "/home/user/.minecraft/saves/foo/bar": False
+        }[path]
+
+        self.assertEqual(overviewer.resolve_world_path("foo/bar"), "foo/bar")
+
+    @patch('os.path.sep', new='/')
+    @patch('os.path.expanduser', return_value='/home/user')
+    @patch('platform.system', return_value='Linux')
+    @patch('os.path.exists')
+    def test_fail_resolve_no_local(self, mock_exists, *args):
+        mock_exists.side_effect = lambda path: {
+            "foo/bar": False,
+            "/home/user/.minecraft/saves/foo/bar": False
+        }[path]
+
+        self.assertEqual(overviewer.resolve_world_path("foo/bar"), None)
+
+
+    @patch('os.path.sep', new='/')
+    @patch('os.path.expanduser', return_value='/home/user')
+    @patch('platform.system', return_value='Linux')
+    @patch('os.path.exists')
+    def test_fail_resolve(self, mock_exists, *args):
+        mock_exists.side_effect = lambda path: {
+            "missing": False,
+            "/home/user/.minecraft/saves/missing": False
+        }[path]
+
+        self.assertEqual(overviewer.resolve_world_path("missing"), None)


### PR DESCRIPTION
Prior to 4c7429691b479c8eb5257392fb738293f2497f6c, Overviewer would default to looking using the current directory as the base for finding the world file. Thus, if you were in `/home/user/example` and had a world called `myworld` at `/home/user/example/myworld` you wish to render, and a copy in `/home/user/.minecraft/saves/myworld`, Overviewer would prefer to render the version at `/home/user/example/myworld`.

This change preserves the legacy behaviour while still supporting a fallback to check the Minecraft saves folder in case the path doesn't exist locally. This behaviour is verified using a set of unit tests.

Change-Id: I91f088a129cded5adcb3d7f2739a2f3ef0d8af8f