### PR TITLE
1.21.5: Text component format changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install networkx pytest
+          pip install pytest pytest-mock
           echo "PIL_INCLUDE_DIR=pillow/src/libImaging" >> "$GITHUB_ENV"
 
       - name: Build Overviewer

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ overviewer_core/c_overviewer*.dylib
 overviewer_core/overviewer_version.py
 overviewer_core/src/primitives.h
 
+overviewer_core/data/stylesheet_src/*.css
+overviewer_core/data/stylesheet_src/*.css.map
+
 # Mac OS X noise
 .DS_Store
 

--- a/docs/signs.rst
+++ b/docs/signs.rst
@@ -25,15 +25,19 @@ The function should accept one argument (a dictionary, also know as an associati
 array), and return a string representing the text to be displayed.  For example::
 
     def signFilter(poi):
-        if poi['id'] == 'Sign' or poi['id'] == 'minecraft:sign':
-            return "\n".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
+        if poi['id'] in ['minecraft:sign', 'minecraft:hanging_sign']:
+            return "<br />".join(poi['front_text']['messagesHtml'])
 
 .. note::
-    This example is intended as a teaching aid and does not escape HTML,
-    so if you are concerned that your Minecraft players will put HTML/JS into
-    their signs, see below for a version that does do escaping.
+    `messagesHtml` is a parsed and escaped version of the text on a sign. If you need
+    the raw sign text for filtering, use `messages` instead. Be aware that `messages`
+    is not safe for displaying directly as players could inject HTML/JS into your map
+    through signs. Prefer to use messagesHtml (or `CustomNameHtml` for entity names)
+    whenever displaying user-provided data.
 
-If a POI doesn't match, the filter can return None (which is the default if a python 
+Rendering formatted text in HTML is supported for sign text and entity names only.
+
+If a POI doesn't match, the filter can return None (which is the default if a python
 functions runs off the end without an explicit 'return').
 
 The single argument will either a TileEntity, or an Entity taken directly from 

--- a/overviewer_core/data/stylesheet_src/textFormat.scss
+++ b/overviewer_core/data/stylesheet_src/textFormat.scss
@@ -1,0 +1,55 @@
+/* Custom JSON text data */
+$json-colours: (
+        "black": #000000,
+        "dark_blue": #0000AA,
+        "dark_green": #00AA00,
+        "dark_aqua": #00AAAA,
+        "dark_red": #AA0000,
+        "dark_purple": #AA00AA,
+        "gold": #FFAA00,
+        "gray": #AAAAAA,
+        "dark_gray": #555555,
+        "blue": #5555FF,
+        "green": #55FF55,
+        "aqua": #55FFFF,
+        "red": #FF5555,
+        "light_purple": #FF55FF,
+        "yellow": #FFFF55,
+        "white": #FFFFFF,
+);
+
+.mctext-obfuscated {
+  text-shadow: 0 0 6px black, 0 0 6px black, 0 0 6px black, 0 0 6px black, 0 0 8px black, 0 0 8px black;
+  color: transparent;
+}
+
+@each $colourName, $colourHex in $json-colours {
+  .mctext-#{$colourName} {
+    color: #{$colourHex};
+  }
+
+  .mctext-#{$colourName}.mctext-obfuscated {
+    text-shadow: 0 0 6px #{$colourHex}, 0 0 6px #{$colourHex}, 0 0 6px #{$colourHex}, 0 0 6px #{$colourHex}, 0 0 8px #{$colourHex}, 0 0 8px #{$colourHex};
+    color: transparent;
+  }
+}
+
+.mctext-bold {
+  font-weight: bolder;
+}
+
+.mctext-italic {
+  font-style: italic;
+}
+
+.mctext-underlined {
+  text-decoration: underline;
+}
+
+.mctext-strikethrough {
+  text-decoration: line-through;
+}
+
+.mctext-strikethrough.mctext-underlined {
+  text-decoration: line-through underline;
+}

--- a/overviewer_core/data/web_assets/overviewer.css
+++ b/overviewer_core/data/web_assets/overviewer.css
@@ -197,3 +197,175 @@ div.ov-marker-legend img {
     background: 0;
     border: 0;
 }
+
+
+/** GENERATED: DO NOT MODIFY DIRECTLY **/
+.mctext-obfuscated {
+  text-shadow: 0 0 6px black, 0 0 6px black, 0 0 6px black, 0 0 6px black, 0 0 8px black, 0 0 8px black;
+  color: transparent;
+}
+
+.mctext-black {
+  color: #000000;
+}
+
+.mctext-black.mctext-obfuscated {
+  text-shadow: 0 0 6px #000000, 0 0 6px #000000, 0 0 6px #000000, 0 0 6px #000000, 0 0 8px #000000, 0 0 8px #000000;
+  color: transparent;
+}
+
+.mctext-dark_blue {
+  color: #0000AA;
+}
+
+.mctext-dark_blue.mctext-obfuscated {
+  text-shadow: 0 0 6px #0000AA, 0 0 6px #0000AA, 0 0 6px #0000AA, 0 0 6px #0000AA, 0 0 8px #0000AA, 0 0 8px #0000AA;
+  color: transparent;
+}
+
+.mctext-dark_green {
+  color: #00AA00;
+}
+
+.mctext-dark_green.mctext-obfuscated {
+  text-shadow: 0 0 6px #00AA00, 0 0 6px #00AA00, 0 0 6px #00AA00, 0 0 6px #00AA00, 0 0 8px #00AA00, 0 0 8px #00AA00;
+  color: transparent;
+}
+
+.mctext-dark_aqua {
+  color: #00AAAA;
+}
+
+.mctext-dark_aqua.mctext-obfuscated {
+  text-shadow: 0 0 6px #00AAAA, 0 0 6px #00AAAA, 0 0 6px #00AAAA, 0 0 6px #00AAAA, 0 0 8px #00AAAA, 0 0 8px #00AAAA;
+  color: transparent;
+}
+
+.mctext-dark_red {
+  color: #AA0000;
+}
+
+.mctext-dark_red.mctext-obfuscated {
+  text-shadow: 0 0 6px #AA0000, 0 0 6px #AA0000, 0 0 6px #AA0000, 0 0 6px #AA0000, 0 0 8px #AA0000, 0 0 8px #AA0000;
+  color: transparent;
+}
+
+.mctext-dark_purple {
+  color: #AA00AA;
+}
+
+.mctext-dark_purple.mctext-obfuscated {
+  text-shadow: 0 0 6px #AA00AA, 0 0 6px #AA00AA, 0 0 6px #AA00AA, 0 0 6px #AA00AA, 0 0 8px #AA00AA, 0 0 8px #AA00AA;
+  color: transparent;
+}
+
+.mctext-gold {
+  color: #FFAA00;
+}
+
+.mctext-gold.mctext-obfuscated {
+  text-shadow: 0 0 6px #FFAA00, 0 0 6px #FFAA00, 0 0 6px #FFAA00, 0 0 6px #FFAA00, 0 0 8px #FFAA00, 0 0 8px #FFAA00;
+  color: transparent;
+}
+
+.mctext-gray {
+  color: #AAAAAA;
+}
+
+.mctext-gray.mctext-obfuscated {
+  text-shadow: 0 0 6px #AAAAAA, 0 0 6px #AAAAAA, 0 0 6px #AAAAAA, 0 0 6px #AAAAAA, 0 0 8px #AAAAAA, 0 0 8px #AAAAAA;
+  color: transparent;
+}
+
+.mctext-dark_gray {
+  color: #555555;
+}
+
+.mctext-dark_gray.mctext-obfuscated {
+  text-shadow: 0 0 6px #555555, 0 0 6px #555555, 0 0 6px #555555, 0 0 6px #555555, 0 0 8px #555555, 0 0 8px #555555;
+  color: transparent;
+}
+
+.mctext-blue {
+  color: #5555FF;
+}
+
+.mctext-blue.mctext-obfuscated {
+  text-shadow: 0 0 6px #5555FF, 0 0 6px #5555FF, 0 0 6px #5555FF, 0 0 6px #5555FF, 0 0 8px #5555FF, 0 0 8px #5555FF;
+  color: transparent;
+}
+
+.mctext-green {
+  color: #55FF55;
+}
+
+.mctext-green.mctext-obfuscated {
+  text-shadow: 0 0 6px #55FF55, 0 0 6px #55FF55, 0 0 6px #55FF55, 0 0 6px #55FF55, 0 0 8px #55FF55, 0 0 8px #55FF55;
+  color: transparent;
+}
+
+.mctext-aqua {
+  color: #55FFFF;
+}
+
+.mctext-aqua.mctext-obfuscated {
+  text-shadow: 0 0 6px #55FFFF, 0 0 6px #55FFFF, 0 0 6px #55FFFF, 0 0 6px #55FFFF, 0 0 8px #55FFFF, 0 0 8px #55FFFF;
+  color: transparent;
+}
+
+.mctext-red {
+  color: #FF5555;
+}
+
+.mctext-red.mctext-obfuscated {
+  text-shadow: 0 0 6px #FF5555, 0 0 6px #FF5555, 0 0 6px #FF5555, 0 0 6px #FF5555, 0 0 8px #FF5555, 0 0 8px #FF5555;
+  color: transparent;
+}
+
+.mctext-light_purple {
+  color: #FF55FF;
+}
+
+.mctext-light_purple.mctext-obfuscated {
+  text-shadow: 0 0 6px #FF55FF, 0 0 6px #FF55FF, 0 0 6px #FF55FF, 0 0 6px #FF55FF, 0 0 8px #FF55FF, 0 0 8px #FF55FF;
+  color: transparent;
+}
+
+.mctext-yellow {
+  color: #FFFF55;
+}
+
+.mctext-yellow.mctext-obfuscated {
+  text-shadow: 0 0 6px #FFFF55, 0 0 6px #FFFF55, 0 0 6px #FFFF55, 0 0 6px #FFFF55, 0 0 8px #FFFF55, 0 0 8px #FFFF55;
+  color: transparent;
+}
+
+.mctext-white {
+  color: #FFFFFF;
+}
+
+.mctext-white.mctext-obfuscated {
+  text-shadow: 0 0 6px #FFFFFF, 0 0 6px #FFFFFF, 0 0 6px #FFFFFF, 0 0 6px #FFFFFF, 0 0 8px #FFFFFF, 0 0 8px #FFFFFF;
+  color: transparent;
+}
+
+.mctext-bold {
+  font-weight: bolder;
+}
+
+.mctext-italic {
+  font-style: italic;
+}
+
+.mctext-underlined {
+  text-decoration: underline;
+}
+
+.mctext-strikethrough {
+  text-decoration: line-through;
+}
+
+.mctext-strikethrough.mctext-underlined {
+  text-decoration: line-through underline;
+}
+/** END GENERATED SECTION **/

--- a/overviewer_core/textParser.py
+++ b/overviewer_core/textParser.py
@@ -1,0 +1,301 @@
+import json
+from logging import Logger
+
+
+class TextParser(object):
+    """A class to wrap up all the text component format logic into one easy-to-use
+    and hopefully easy-to-debug format
+    """
+
+    # No DataVersion attribute available. Pre 1.9.
+    SIGN_FORMAT_1070 = 0
+    # First used DataVersion (15w32a / 1.9)
+    SIGN_FORMAT_1090 = 100
+    # hanging sign = 3205 / 22w42a / 1.19.3
+    SIGN_FORMAT_1193 = 3205
+    # sign text on both sides = 3442 / 23w12a / 1.20
+    SIGN_FORMAT_1200 = 3442
+    # new text component data format = 4298 / 25w02a / 1.21.5
+    SIGN_FORMAT_1215 = 4298
+
+    JSON_TEXT_COLOURS = [
+        "black", "dark_blue", "dark_green", "dark_aqua",
+        "dark_red", "dark_purple", "gold", "gray",
+        "dark_gray", "blue", "green", "aqua",
+        "red", "light_purple", "yellow", "white"
+    ]
+
+    def __init__(self, logger: Logger):
+        self.logger = logger
+
+    def parse_sign(self, poi: dict, chunk_data_version: int) -> None:
+        """
+        Takes a sign POI and parses the text components into a plain text format,
+        and provides an HTML formatted version of the text.
+
+        This mutates the original POI object.
+        """
+
+        if poi['id'] in ['Sign', 'minecraft:sign', 'minecraft:hanging_sign']:
+            pass
+
+        if 'Text1' in poi:
+            # Legacy sign; upgrade to modern NBT layout
+            self.__sign_from_legacy(poi, chunk_data_version)
+
+        poi['front_text']['messagesHtml'] = [self.parse_text_component(i, chunk_data_version, True) for i in
+                                             poi['front_text']['messages']]
+        poi['front_text']['messages'] = [self.parse_text_component(i, chunk_data_version, False) for i in
+                                         poi['front_text']['messages']]
+
+        poi['back_text']['messagesHtml'] = [self.parse_text_component(i, chunk_data_version, True) for i in
+                                            poi['back_text']['messages']]
+        poi['back_text']['messages'] = [self.parse_text_component(i, chunk_data_version, False) for i in
+                                        poi['back_text']['messages']]
+
+    def __sign_from_legacy(self, poi: dict, chunk_data_version: int) -> None:
+        """
+        Upgrades a sign POI from the legacy Text1/Text2/etc format to the modern 1.20
+        front_text.messages/back_text.messages format
+
+        This mutates the original POI object.
+        """
+
+        if 'Text1' not in poi:
+            # Not a legacy sign?
+            return
+
+        if poi['id'] == 'Sign':
+            poi['id'] = 'minecraft:sign'
+
+        empty_text = '""'
+        if chunk_data_version == self.SIGN_FORMAT_1070:
+            # Don't know if this should be old or not. See if there's precedent.
+            # If not, assume 1.8 format. There's no good options here.
+            if '' in [poi["Text1"], poi["Text2"], poi["Text3"], poi["Text4"]]:
+                empty_text = ''
+
+        poi.update({
+            "back_text": {
+                "has_glowing_text": 0,
+                "color": "black",
+                "messages": [empty_text, empty_text, empty_text, empty_text],
+            },
+            "front_text": {
+                "has_glowing_text": poi.get('GlowingText', 0),
+                "color": poi.get('Color', 'black'),
+                "messages": [poi["Text1"], poi["Text2"], poi["Text3"], poi["Text4"]],
+            },
+            "keepPacked": 0,
+            "is_waxed": 0,
+        })
+
+        poi.pop('Text1', None)
+        poi.pop('Text2', None)
+        poi.pop('Text3', None)
+        poi.pop('Text4', None)
+        poi.pop('GlowingText', None)
+        poi.pop('Color', None)
+
+    def parse_text_component(self, data, chunk_data_version: int, html_output: bool) -> str:
+        if chunk_data_version >= self.SIGN_FORMAT_1215:
+            # Guaranteed to be 1.21.5 format.
+            return self.__parse_text_component_1215(data, html_output)
+
+        if not isinstance(data, str):
+            # All other earlier formats used text representations.
+            # Something is really wrong.
+            self.logger.error(
+                "Requested parse of text component %s with data version %d, but text component is not a string!", data,
+                chunk_data_version)
+            return ''
+
+        if chunk_data_version >= self.SIGN_FORMAT_1090:
+            # Guaranteed to be 1.8 format.
+            return self.__parse_text_component_1080(data, html_output)
+
+        if chunk_data_version == self.SIGN_FORMAT_1070:
+            if data is None or data == "null":
+                return ""
+            if data.startswith('"') and data.endswith('"'):
+                # Starts and ends with string markers. Probably 1.8 format, but not guaranteed.
+                return self.__parse_text_component_1080(data, html_output)
+            if data.startswith('{') and data.endswith('}'):
+                # Starts and ends with object markers. Probably 1.8 format, but not guaranteed.
+                return self.__parse_text_component_1080(data, html_output)
+
+            # Unlikely to be 1.8 format, so assume 1.7 format.
+            return data
+
+        self.logger.error("Unknown text component format %d", chunk_data_version)
+        return ''
+
+    def __parse_text_component_1080(self, data: str, html_output: bool) -> str:
+        try:
+            js = json.loads(data)
+        except ValueError as ex:
+            self.logger.warning("Failed parsing JSON text `%s`", data, exc_info=ex)
+            return data
+
+        # This format is essentially the same as the new format
+        return self.__parse_text_component_1215(js, html_output)
+
+    def __parse_text_component_1215(self, data, html_output: bool) -> str:
+        # This format pulls the old JSON format up into the real NBT data structure.
+
+        if isinstance(data, str):
+            # If there's a string here, it's a real string
+            return data
+
+        style = TextStyleState(html_output)
+        all_components = []
+
+        def parse_recursive(component, parent_style: TextStyleState) -> None:
+            """
+            Recursively parse a text component based on its type.
+            """
+            if isinstance(component, str):
+                # It's a string, so there's no style overrides here. Just use the parent
+                # style.
+                all_components.append((component, parent_style))
+            if isinstance(component, list):
+                # List, fall back to the list parser
+                parse_list(component, parent_style)
+            if isinstance(component, dict):
+                # Dict, fall back to the dict parser
+                parse_dict(component, parent_style)
+
+        def parse_list(component: list, parent_style: TextStyleState) -> None:
+            """
+            Handle a text component that happens to be a list.
+
+            If there's a single component, then just treat that as a component on its own
+
+            If there's multiple, the documentation says that it should be:
+              " Same as having all components after the first one appended to the first's extra array"
+            """
+            if len(component) == 0:
+                # nothing to do
+                pass
+            if len(component) == 1:
+                parse_recursive(component[0], parent_style)
+            if len(component) > 1:
+                # Lists are treated as a single component with other items forming
+                # part of the "extra" list.
+                new_component = component[0]
+                new_component['extra'] = component[1:]
+                parse_recursive(new_component, parent_style)
+
+        def parse_dict(component: dict, parent_style: TextStyleState) -> None:
+            """
+            A "proper" text component, with style overrides etc.
+
+            We're not going to handle different fonts. That's too far.
+            """
+            # Some components are stored as an empty dict with a single empty key to work around NBT storage constraints
+            if '' in component:
+                # This will only ever be plain text.
+                all_components.append((component[''], parent_style))
+                return
+
+            component_style = parent_style.copy()
+
+            if 'color' in component:
+                if component['color'] in self.JSON_TEXT_COLOURS:
+                    component_style.colour = component['color']
+                elif component['color'].startswith('#'):
+                    component_style.colour = component['color']
+
+            if 'bold' in component:
+                component_style.bold = component['bold']
+            if 'italic' in component:
+                component_style.italic = component['italic']
+            if 'underlined' in component:
+                component_style.underlined = component['underlined']
+            if 'strikethrough' in component:
+                component_style.strikethrough = component['strikethrough']
+            if 'obfuscated' in component:
+                component_style.obfuscated = component['obfuscated']
+
+            if 'text' in component:
+                all_components.append((component['text'], component_style))
+
+            if "extra" in component and len(component["extra"]) > 0:
+                for extra in component["extra"]:
+                    parse_recursive(extra, component_style)
+
+        parse_recursive(data, style)
+
+        return ''.join([y.open_tag() + x + y.close_tag() for (x, y) in all_components])
+
+
+class TextStyleState(object):
+    def __init__(self, html_output: bool) -> None:
+        self.html_output = html_output
+        self.closing_tag = ''
+
+        self.bold = False
+        self.italic = False
+        self.underlined = False
+        self.strikethrough = False
+        self.obfuscated = False
+        self.colour = None
+
+    def copy(self) -> "TextStyleState":
+        new = TextStyleState(self.html_output)
+        new.bold = self.bold
+        new.italic = self.italic
+        new.underlined = self.underlined
+        new.strikethrough = self.strikethrough
+        new.obfuscated = self.obfuscated
+        new.colour = self.colour
+
+        return new
+
+    def close_tag(self):
+        return self.closing_tag
+
+    def open_tag(self) -> str:
+        if not self.html_output:
+            self.closing_tag = ''
+            return ''
+
+        style_attr = ''
+        classes = []
+        custom_colour = False
+
+        if self.colour is not None:
+            if self.colour in TextParser.JSON_TEXT_COLOURS:
+                classes.append(f'mctext-{self.colour}')
+            else:
+                if not self.obfuscated:
+                    style_attr += f'color: {self.colour};'
+                custom_colour = True
+
+        if self.bold:
+            classes.append('mctext-bold')
+        if self.italic:
+            classes.append('mctext-italic')
+        if self.underlined:
+            classes.append('mctext-underlined')
+        if self.strikethrough:
+            classes.append('mctext-strikethrough')
+
+        if self.obfuscated:
+            if not custom_colour:
+                classes.append('mctext-obfuscated')
+            else:
+                # thanks, I hate it.
+                style_attr += f'text-shadow: 0 0 6px {self.colour}, 0 0 6px {self.colour}, 0 0 6px {self.colour}, 0 0 6px {self.colour}, 0 0 8px {self.colour}, 0 0 8px {self.colour};color: transparent;'
+
+        if len(classes) == 0 and len(style_attr) == 0:
+            # No styling needed
+            self.closing_tag = ''
+            return ''
+
+        if style_attr != '':
+            style_attr = f' style="{style_attr}"'
+
+        self.closing_tag = '</span>'
+        combined_classes = ' '.join(classes)
+        return f'<span class="{combined_classes}"{style_attr}>'

--- a/test/test_textParser.py
+++ b/test/test_textParser.py
@@ -1,0 +1,262 @@
+import pytest
+from overviewer_core.textParser import TextParser
+from overviewer_core.textParser import TextStyleState
+
+
+def test_sign_upgrade_170(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    poi = {
+        "id": "Sign",
+        "x": 0,
+        "y": 0,
+        "z": 0,
+        "Text1": "test",
+        "Text2": "",
+        "Text3": "",
+        "Text4": "",
+    }
+
+    parser._TextParser__sign_from_legacy(poi, TextParser.SIGN_FORMAT_1070)
+
+    assert poi["id"] == "minecraft:sign"
+    assert "Text1" not in poi
+    assert "Text2" not in poi
+    assert "Text3" not in poi
+    assert "Text4" not in poi
+    assert poi["front_text"]["messages"][0] == 'test'
+    assert poi["front_text"]["messages"][1] == ''
+    assert poi["front_text"]["messages"][2] == ''
+    assert poi["front_text"]["messages"][3] == ''
+    assert poi["front_text"]["color"] == "black"
+    assert poi["front_text"]["has_glowing_text"] == 0
+    assert poi["back_text"]["messages"][0] == ''
+    assert poi["back_text"]["messages"][1] == ''
+    assert poi["back_text"]["messages"][2] == ''
+    assert poi["back_text"]["messages"][3] == ''
+    assert poi["back_text"]["color"] == "black"
+    assert poi["back_text"]["has_glowing_text"] == 0
+
+
+def test_sign_upgrade_1140(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    poi = {
+        "id": "minecraft:sign",
+        "x": 0,
+        "y": 0,
+        "z": 0,
+        "Color": "green",
+        "Text1": '"test"',
+        "Text2": '""',
+        "Text3": '""',
+        "Text4": '""',
+    }
+
+    parser._TextParser__sign_from_legacy(poi, TextParser.SIGN_FORMAT_1090)
+
+    assert poi["id"] == "minecraft:sign"
+    assert "Text1" not in poi
+    assert "Text2" not in poi
+    assert "Text3" not in poi
+    assert "Text4" not in poi
+    assert poi["front_text"]["messages"][0] == '"test"'
+    assert poi["front_text"]["messages"][1] == '""'
+    assert poi["front_text"]["messages"][2] == '""'
+    assert poi["front_text"]["messages"][3] == '""'
+    assert poi["front_text"]["color"] == "green"
+    assert poi["front_text"]["has_glowing_text"] == 0
+    assert poi["back_text"]["messages"][0] == '""'
+    assert poi["back_text"]["messages"][1] == '""'
+    assert poi["back_text"]["messages"][2] == '""'
+    assert poi["back_text"]["messages"][3] == '""'
+    assert poi["back_text"]["color"] == "black"
+    assert poi["back_text"]["has_glowing_text"] == 0
+
+
+def test_sign_upgrade_1170(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    poi = {
+        "id": "minecraft:sign",
+        "x": 0,
+        "y": 0,
+        "z": 0,
+        "Color": "green",
+        "GlowingText": 1,
+        "Text1": '"test"',
+        "Text2": '""',
+        "Text3": '""',
+        "Text4": '""',
+    }
+
+    parser._TextParser__sign_from_legacy(poi, TextParser.SIGN_FORMAT_1090)
+
+    assert poi["id"] == "minecraft:sign"
+    assert "Text1" not in poi
+    assert "Text2" not in poi
+    assert "Text3" not in poi
+    assert "Text4" not in poi
+    assert poi["front_text"]["messages"][0] == '"test"'
+    assert poi["front_text"]["messages"][1] == '""'
+    assert poi["front_text"]["messages"][2] == '""'
+    assert poi["front_text"]["messages"][3] == '""'
+    assert poi["front_text"]["color"] == "green"
+    assert poi["front_text"]["has_glowing_text"] == 1
+    assert poi["back_text"]["messages"][0] == '""'
+    assert poi["back_text"]["messages"][1] == '""'
+    assert poi["back_text"]["messages"][2] == '""'
+    assert poi["back_text"]["messages"][3] == '""'
+    assert poi["back_text"]["color"] == "black"
+    assert poi["back_text"]["has_glowing_text"] == 0
+
+
+def test_sign_text_process(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    poi = {
+        "id": "minecraft:sign",
+        "x": 0,
+        "y": 0,
+        "z": 0,
+        "front_text": {
+            "messages": ['"f1"', '"f2"', '"f3"', '"f4"'],
+            "color": "black",
+            "has_glowing_text": 0,
+        },
+        "back_text": {
+            "messages": ['"b1"', '"b2"', '"b3"', '"b4"'],
+            "color": "black",
+            "has_glowing_text": 0,
+        },
+    }
+
+    parser.parse_sign(poi, TextParser.SIGN_FORMAT_1200)
+
+    assert poi["id"] == "minecraft:sign"
+    assert poi["front_text"]["messages"][0] == 'f1'
+    assert poi["front_text"]["messages"][1] == 'f2'
+    assert poi["front_text"]["messages"][2] == 'f3'
+    assert poi["front_text"]["messages"][3] == 'f4'
+    assert poi["front_text"]["messagesHtml"][0] == 'f1'
+    assert poi["front_text"]["messagesHtml"][1] == 'f2'
+    assert poi["front_text"]["messagesHtml"][2] == 'f3'
+    assert poi["front_text"]["messagesHtml"][3] == 'f4'
+    assert poi["back_text"]["messages"][0] == 'b1'
+    assert poi["back_text"]["messages"][1] == 'b2'
+    assert poi["back_text"]["messages"][2] == 'b3'
+    assert poi["back_text"]["messages"][3] == 'b4'
+    assert poi["back_text"]["messagesHtml"][0] == 'b1'
+    assert poi["back_text"]["messagesHtml"][1] == 'b2'
+    assert poi["back_text"]["messagesHtml"][2] == 'b3'
+    assert poi["back_text"]["messagesHtml"][3] == 'b4'
+
+def test_1215_string(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    data = "test"
+
+    result = parser.parse_text_component(data, TextParser.SIGN_FORMAT_1215, False)
+
+    assert result == "test"
+
+def test_1215_basic_component(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    data = {"text": "test"}
+
+    result = parser.parse_text_component(data, TextParser.SIGN_FORMAT_1215, False)
+
+    assert result == "test"
+
+# All these test cases have been verified in-game via
+# /data modify block <x> <y> <z> front_text.messages[0] set value <data>
+@pytest.mark.parametrize('data,expected',[
+  pytest.param({"text": "test"}, "test", id="basic"),
+  pytest.param({"text":"goo","color":"#FF00FF"}, "goo", id="basic_coloured"),
+  pytest.param({"text":"a","color":"red","extra":["b", "c"]}, "abc", id="basic_extra_strings"),
+  pytest.param({"text":"a","extra":[{"text":"b"},{"text":"c"}]}, "abc", id="extra_components"),
+  pytest.param({"text":"a","extra":[{"text":"b"},{"":"c"}]}, "abc", id="extra_components_with_empty_object"),
+  pytest.param({"text":"a","extra":[{"text":"b","extra":[{"text":"c"}]}]}, "abc", id="nested_components"),
+  pytest.param({"text":"a","extra":[{"text":"b","extra":[{"text":"c"},"d"]},{"text":"e","extra":[{"text":"f"},{"text":"g"}]}]}, "abcdefg", id="confusing_nesting"),
+  pytest.param({"extra":["b", "c"],"text":"a"}, "abc", id="odd_order"),
+])
+def test_1215_components_plain(mocker, data, expected):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+
+    result = parser.parse_text_component(data, TextParser.SIGN_FORMAT_1215, False)
+
+    assert result == expected
+
+def test_textstyle_no_html():
+    style = TextStyleState(False)
+    style.bold = True
+    style.color = "#FF0000"
+    style.obfuscated = True
+
+    assert style.open_tag() == ''
+    assert style.close_tag() == ''
+
+def test_textstyle_unstyled_html():
+    style = TextStyleState(True)
+
+    assert style.open_tag() == ''
+    assert style.close_tag() == ''
+
+def test_textstyle_styled_html():
+    style = TextStyleState(True)
+
+    style.bold = True
+    style.colour = "red"
+
+    assert style.open_tag() == '<span class="mctext-red mctext-bold">'
+    assert style.close_tag() == '</span>'
+
+
+def test_textstyle_allbool_styled():
+    style = TextStyleState(True)
+
+    style.bold = True
+    style.italic = True
+    style.underlined = True
+    style.strikethrough = True
+    style.obfuscated = True
+
+    assert style.open_tag() == '<span class="mctext-bold mctext-italic mctext-underlined mctext-strikethrough mctext-obfuscated">'
+    assert style.close_tag() == '</span>'
+
+
+def test_textstyle_custom_colour():
+    style = TextStyleState(True)
+
+    style.colour = '#ffbb33'
+
+    assert style.open_tag() == '<span class="" style="color: #ffbb33;">'
+    assert style.close_tag() == '</span>'
+
+def test_textstyle_custom_colour_obfuscated():
+    style = TextStyleState(True)
+
+    style.colour = '#ffbb33'
+    style.obfuscated = True
+
+    assert style.open_tag() == '<span class="" style="text-shadow: 0 0 6px #ffbb33, 0 0 6px #ffbb33, 0 0 6px #ffbb33, 0 0 6px #ffbb33, 0 0 8px #ffbb33, 0 0 8px #ffbb33;color: transparent;">'
+    assert style.close_tag() == '</span>'
+
+@pytest.mark.parametrize('data,expected',[
+  pytest.param({"text": "test"}, 'test', id="basic"),
+  pytest.param({"text":"goo","color":"#FF00FF"}, '<span class="" style="color: #FF00FF;">goo</span>', id="basic_coloured"),
+  pytest.param({"text":"a","color":"red","extra":["b", "c"]}, '<span class="mctext-red">a</span><span class="mctext-red">b</span><span class="mctext-red">c</span>', id="basic_extra_strings"),
+  pytest.param({"text":"a","color":"red","extra":[{"text":"b","color":"blue"}, "c"]}, '<span class="mctext-red">a</span><span class="mctext-blue">b</span><span class="mctext-red">c</span>', id="overriden"),
+  pytest.param({"text":"a","color":"red","extra":[{"text":"b","color":"blue"}, {"": "c"}]}, '<span class="mctext-red">a</span><span class="mctext-blue">b</span><span class="mctext-red">c</span>', id="overriden_with_empty_component"),
+  pytest.param({"text":"a","color":"red","bold":True,"extra":[{"text":"b","color":"blue"}, "c"]}, '<span class="mctext-red mctext-bold">a</span><span class="mctext-blue mctext-bold">b</span><span class="mctext-red mctext-bold">c</span>', id="overriden_bold"),
+  pytest.param({"text":"a","color":"red","bold":True,"extra":[{"text":"b","color":"blue","bold":False}, "c"]}, '<span class="mctext-red mctext-bold">a</span><span class="mctext-blue">b</span><span class="mctext-red mctext-bold">c</span>', id="overriden_unbold")
+])
+def test_1215_components_html(mocker, data, expected):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+
+    result = parser.parse_text_component(data, TextParser.SIGN_FORMAT_1215, True)
+
+    assert result == expected

--- a/test/test_textParser.py
+++ b/test/test_textParser.py
@@ -160,6 +160,32 @@ def test_1215_string(mocker):
 
     assert result == "test"
 
+def test_1215_xss(mocker):
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    data = "<script>alert('')/*"
+
+    result = parser.parse_text_component(data, TextParser.SIGN_FORMAT_1215, True)
+
+    assert result == "&lt;script&gt;alert(&#x27;&#x27;)/*"
+
+def test_1215_xss_nonrendered(mocker):
+    """
+    I'm purposefully *not* escaping non-HTML rendered things here. The documentation states that you
+    need to escape it already, and changing this to escape all text could break existing filter functions
+    that rely on searching for < and >.
+
+    Really, non-HTML messages should never be written to the client and only used within filter functions
+    themselves. Rely on messagesHtml for things you want to write to the client.
+    """
+    logger = mocker.Mock()
+    parser = TextParser(logger)
+    data = "<script>alert('')/*"
+
+    result = parser.parse_text_component(data, TextParser.SIGN_FORMAT_1215, False)
+
+    assert result == "<script>alert('')/*"
+
 def test_1215_basic_component(mocker):
     logger = mocker.Mock()
     parser = TextParser(logger)


### PR DESCRIPTION
Due to changes in 1.21.5 to the text component data format, the `jsonText` function in genPOI has broken and no longer parses text from POIs.

This change rips out the old `jsonText` and `signWrangler` functions entirely, and replaces both with a new `TextParser` class which handles the logic of parsing text from all Minecraft versions, up to and including 1.21.5.

This is a breaking change to undocumented functionality - prior to this change, we made `*Raw` versions of text components available for end users to implement their own parsing logic. For example, signs implemented a `Text1` and `Text1Raw` for the first line of sign text (or `front_text.messages` / `front_text.messagesRaw` for modern signs). The first "non-raw" version included the unformatted content of the text, parsed into a simple string. This is commonly used for filtering text on signs. The `*Raw` version included the unprocessed JSON string to allow end users to write their own parsing logic such that formatted text could be rendered into HTML as needed.

This change removes the `*Raw` properties where they were added. In it's place, `*Html` versions of the properties have been added which include HTML-formatted versions of the text components. Styles are applied via CSS, which can be easily overridden by end users if desired. The new functionality is covered by unit tests and documented under the docs/ folder.

To my knowledge, only one instance of Overviewer used this undocumented functionality. That instance has since upgraded to the new functionality of this PR, and has been acting as a beta test for these changes for several weeks. We should still document this as a breaking change anyway, just in case there others who've made use of it.

---

There's also a bit of a refactor of the `get_chunk` / `get_chunk_lite` function too to reduce code duplication.