### PR TITLE
Fixing up overviewer for minecraft version 1.21.10+

### DIFF
--- a/overviewer_core/textures.py
+++ b/overviewer_core/textures.py
@@ -7764,3 +7764,4 @@ block(blockid=12649, top_image=BLOCKTEXTURE + "oxidized_copper_grate.png", trans
 block(blockid=12663, top_image=BLOCKTEXTURE + "chiseled_tuff.png")
 block(blockid=12666, top_image=BLOCKTEXTURE + "polished_tuff.png")
 block(blockid=12669, top_image=BLOCKTEXTURE + "tuff_bricks.png")
+block(blockid=12670, top_image=BLOCKTEXTURE + "chiseled_tuff_bricks.png")

--- a/overviewer_core/world.py
+++ b/overviewer_core/world.py
@@ -194,16 +194,16 @@ class World(object):
         ## read spawn info from level.dat
         data = self.leveldat
 
-        ## Versions prior to 1.21.10 can read directly from the level.dat
         try:
-           disp_spawnX = spawnX = data['SpawnX']
-           spawnY = data['SpawnY']
-           disp_spawnZ = spawnZ = data['SpawnZ']
-        except KeyError:
             ## Versions after 1.21.10 pull from a spawn pos array
-            disp_spawnX = spawnX = data['spawn']['pos'][0]
+            spawnX = data['spawn']['pos'][0]
             spawnY = data['spawn']['pos'][1]
-            disp_spawnZ = spawnZ = data['spawn']['pos'][2]
+            spawnZ = data['spawn']['pos'][2]
+        except KeyError:
+            ## Versions prior to 1.21.10 can read directly from the level.dat
+            spawnX = data['SpawnX']
+            spawnY = data['SpawnY']
+            spawnZ = data['SpawnZ']
 
 
         ## clamp spawnY to a sane value, in-chunk value


### PR DESCRIPTION
Making adjustments to allow for overview usage in Minecraft version 1.21.10; to fix issues in #95 
* Adding a fall back for "chain.png" to use the texture "iron_chain.png" if chain fails to load
* Adding a spawn fallback if the spawn details can't be read from the level.dat file, fall back uses the spawn pos array