### PR TITLE
Fix sign/players toggle not appearing in non-overworld render views.

### DIFF
--- a/overviewer_core/data/js_src/util.js
+++ b/overviewer_core/data/js_src/util.js
@@ -269,7 +269,7 @@ overviewer.util = {
             if (overviewer.collections.spawnMarker) {
                 overviewer.collections.spawnMarker.remove();
             }
-            if (typeof(ovconf.spawn) == "object") {
+            if (ovconf.spawn !== null && typeof(ovconf.spawn) == "object") {
                 var spawnIcon = L.icon({
                     iconUrl: overviewerConfig.CONST.image.spawnMarker,
                     iconRetinaUrl: overviewerConfig.CONST.image.spawnMarker2x,


### PR DESCRIPTION
Update javascript to load the 'Players / Signs' toggle element in the UI in all views.
Fixes #110